### PR TITLE
feat(rules): check useless parentheses around new

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -427,7 +427,11 @@
         </properties>
     </rule>
     <!-- Forbid useless parentheses -->
-    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses">
+        <properties>
+            <property name="enableCheckAroundNew" value="true"/>
+        </properties>
+    </rule>
     <!-- Forbid useless semicolon `;` -->
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <!-- Require /* @var type $foo */ and similar simple inline annotations to be replaced by assert() -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -25,10 +25,10 @@ tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           10      0
 tests/input/LowCaseTypes.php                          2       0
-tests/input/namespaces-spacing.php                    7       0
+tests/input/namespaces-spacing.php                    8       0
 tests/input/NamingCamelCase.php                       9       0
 tests/input/negation-operator.php                     2       0
-tests/input/new_with_parentheses.php                  19      0
+tests/input/new_with_parentheses.php                  20      0
 tests/input/not_spacing.php                           8       0
 tests/input/null_coalesce_equal_operator.php          5       0
 tests/input/null_coalesce_operator.php                3       0
@@ -51,13 +51,13 @@ tests/input/TrailingCommaOnFunctions.php              6       0
 tests/input/traits-uses.php                           11      0
 tests/input/type-hints.php                            9       0
 tests/input/UnusedVariables.php                       1       0
-tests/input/use-ordering.php                          1       0
+tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/namespaces-spacing.php
+++ b/tests/fixed/namespaces-spacing.php
@@ -14,7 +14,7 @@ use function time;
 use const DATE_RFC3339;
 
 strrev(
-    (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))
+    new DateTimeImmutable('@' . time(), new DateTimeZone('UTC'))
         ->sub(new DateInterval('P1D'))
         ->format(DATE_RFC3339),
 );

--- a/tests/fixed/new_with_parentheses.php
+++ b/tests/fixed/new_with_parentheses.php
@@ -26,3 +26,5 @@ $z = new stdClass() ? new stdClass() : new stdClass();
 
 $q   = $q ?: new stdClass();
 $e ??= new stdClass();
+
+$dateTime = new DateTimeImmutable()->format('c');

--- a/tests/fixed/use-ordering.php
+++ b/tests/fixed/use-ordering.php
@@ -11,4 +11,4 @@ use function sprintf;
 
 use const PHP_EOL;
 
-echo sprintf('Current date and time is %s', (new DateTimeImmutable())->format(DateTimeInterface::ATOM)) . PHP_EOL;
+echo sprintf('Current date and time is %s', new DateTimeImmutable()->format(DateTimeInterface::ATOM)) . PHP_EOL;

--- a/tests/input/new_with_parentheses.php
+++ b/tests/input/new_with_parentheses.php
@@ -26,3 +26,5 @@ $z = new stdClass ? new stdClass : new stdClass;
 
 $q = $q ?: new stdClass;
 $e = $e ?? new stdClass;
+
+$dateTime = (new DateTimeImmutable())->format('c');

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -21,11 +21,11 @@ index 8547171..f01ece0 100644
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           10      0
  tests/input/LowCaseTypes.php                          2       0
- tests/input/namespaces-spacing.php                    7       0
+ tests/input/namespaces-spacing.php                    8       0
 -tests/input/NamingCamelCase.php                       9       0
 +tests/input/NamingCamelCase.php                       6       0
  tests/input/negation-operator.php                     2       0
- tests/input/new_with_parentheses.php                  19      0
+ tests/input/new_with_parentheses.php                  20      0
  tests/input/not_spacing.php                           8       0
  tests/input/null_coalesce_equal_operator.php          5       0
  tests/input/null_coalesce_operator.php                3       0
@@ -51,16 +51,16 @@ index 8547171..f01ece0 100644
 -tests/input/type-hints.php                            9       0
 +tests/input/type-hints.php                            8       0
  tests/input/UnusedVariables.php                       1       0
- tests/input/use-ordering.php                          1       0
+ tests/input/use-ordering.php                          2       0
  tests/input/useless-semicolon.php                     2       0
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
-+A TOTAL OF 430 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
+-A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 433 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 345 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 348 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.php
 index 480e419..a653086 100644

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -28,15 +28,15 @@ index 9b19b9e..760ee4a 100644
  tests/input/return_type_on_closures.php               26      0
  tests/input/return_type_on_methods.php                22      0
  tests/input/semicolon_spacing.php                     3       0
-@@ -55,7 +54,7 @@ tests/input/use-ordering.php                          1       0
+@@ -55,7 +54,7 @@ tests/input/use-ordering.php                          2       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
-+A TOTAL OF 460 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 463 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 378 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ExampleBackedEnum.php b/tests/fixed/ExampleBackedEnum.php
 index fd701eb..fe54eb9 100644

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -17,15 +17,15 @@ index 8547171..a7a42fa 100644
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
-@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          1       0
+@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          2       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
-+A TOTAL OF 470 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 473 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 385 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 388 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -17,15 +17,15 @@ index 8547171..a7a42fa 100644
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
-@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          1       0
+@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          2       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
-+A TOTAL OF 470 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 473 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 385 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 388 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644


### PR DESCRIPTION
Enables `SlevomatCodingStandard.PHP.UselessParentheses` `enableCheckAroundNew` to report redundant parentheses around `new` expressions before member access.

Raises the minimum `slevomat/coding-standard` version to `^8.24`, where the option was introduced.