### PR TITLE
feat(rules): format DNF types in doc comments

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@15.0.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@15.1.0"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/website-schema.yml
+++ b/.github/workflows/website-schema.yml
@@ -18,4 +18,4 @@ on:
 jobs:
   json-validate:
     name: "Validate JSON schema"
-    uses: "doctrine/.github/.github/workflows/website-schema.yml@15.0.0"
+    uses: "doctrine/.github/.github/workflows/website-schema.yml@15.1.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.28",
+        "slevomat/coding-standard": "^8.29",
         "squizlabs/php_codesniffer": "^4"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.24",
+        "slevomat/coding-standard": "^8.26",
         "squizlabs/php_codesniffer": "^4"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.26",
+        "slevomat/coding-standard": "^8.28",
         "squizlabs/php_codesniffer": "^4"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -503,6 +503,7 @@
             <property name="withSpacesInsideParentheses" value="no" />
             <property name="shortNullable" value="no" />
             <property name="nullPosition" value="last" />
+            <property name="enableForDocComments" value="true" />
         </properties>
     </rule>
     <!-- Forbid useless @var for constants -->

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -277,8 +277,12 @@
     </rule>
     <!-- Forbid fancy yoda conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
-    <!-- Require usage of early exit -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+    <!-- Require usage of early exit where appropriate -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
+        <properties>
+            <property name="ignoreTrailingIfWithOneInstruction" value="true"/>
+        </properties>
+    </rule>
     <!-- Require consistent spacing for jump statements -->
     <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing">
         <properties>

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -128,6 +128,8 @@
             <property name="fixable" value="true"/>
         </properties>
     </rule>
+    <!-- Enforce consistent class keyword order -->
+    <rule ref="SlevomatCodingStandard.Classes.ClassKeywordOrder"/>
     <!-- Enforce consistent constant spacing -->
     <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
     <!-- Forbid LSB for constants (static::FOO) -->

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -168,6 +168,8 @@
     <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>
     <!-- Forbid uses of multiple traits separated by comma -->
     <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+    <!-- Require trait uses to be sorted alphabetically -->
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseOrder"/>
     <!-- Require no spaces before trait use, between trait uses and one space after trait uses -->
     <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -19,7 +19,7 @@ tests/input/ControlStructures.php                     27      0
 tests/input/doc-comment-spacing.php                   11      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           8       0
-tests/input/example-class.php                         48      0
+tests/input/example-class.php                         49      0
 tests/input/ExampleBackedEnum.php                     5       0
 tests/input/Exceptions.php                            1       0
 tests/input/forbidden-comments.php                    14      0
@@ -50,15 +50,15 @@ tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
 tests/input/TrailingCommaOnFunctions.php              6       0
 tests/input/traits-uses.php                           12      0
-tests/input/type-hints.php                            9       0
+tests/input/type-hints.php                            10      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+A TOTAL OF 484 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 398 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -14,10 +14,10 @@ tests/input/ClassPropertySpacing.php                  2       0
 tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         13      0
-tests/input/ControlStructures.php                     28      0
+tests/input/ControlStructures.php                     27      0
 tests/input/doc-comment-spacing.php                   11      0
 tests/input/duplicate-assignment-variable.php         1       0
-tests/input/EarlyReturn.php                           7       0
+tests/input/EarlyReturn.php                           8       0
 tests/input/example-class.php                         48      0
 tests/input/ExampleBackedEnum.php                     5       0
 tests/input/Exceptions.php                            1       0

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -10,6 +10,7 @@ tests/input/assignment-operators.php                  4       0
 tests/input/attributes.php                            15      0
 tests/input/binary_operators.php                      9       0
 tests/input/class-references.php                      10      2
+tests/input/ClassKeywordOrder.php                     1       0
 tests/input/ClassPropertySpacing.php                  2       0
 tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
@@ -55,9 +56,9 @@ tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -49,16 +49,16 @@ tests/input/superfluous-naming.php                    11      0
 tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
 tests/input/TrailingCommaOnFunctions.php              6       0
-tests/input/traits-uses.php                           11      0
+tests/input/traits-uses.php                           12      0
 tests/input/type-hints.php                            9       0
 tests/input/UnusedVariables.php                       1       0
 tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/ClassKeywordOrder.php
+++ b/tests/fixed/ClassKeywordOrder.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClassKeywordOrder;
+
+final readonly class ClassKeywordOrder
+{
+}

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -17,11 +17,9 @@ class ControlStructures
     public function varAndIfNoSpaceBetween(): iterable
     {
         $var = 1;
-        if (self::VERSION !== 0) {
-            return;
+        if (self::VERSION === 0) {
+            yield 0;
         }
-
-        yield 0;
     }
 
     /** @return iterable<int> */

--- a/tests/fixed/EarlyReturn.php
+++ b/tests/fixed/EarlyReturn.php
@@ -41,4 +41,21 @@ class EarlyReturn
 
         return false === false;
     }
+
+    public function trailingIfWithOneInstruction(): void
+    {
+        if ($condition) {
+            echo 'one instruction is left alone';
+        }
+    }
+
+    public function trailingIfWithMultipleInstructions(): void
+    {
+        if (! $condition) {
+            return;
+        }
+
+        echo 'more than one instruction';
+        echo 'still requires an early exit';
+    }
 }

--- a/tests/input/ClassKeywordOrder.php
+++ b/tests/input/ClassKeywordOrder.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClassKeywordOrder;
+
+readonly final class ClassKeywordOrder
+{
+}

--- a/tests/input/EarlyReturn.php
+++ b/tests/input/EarlyReturn.php
@@ -49,4 +49,19 @@ class EarlyReturn
 
         return true;
     }
+
+    public function trailingIfWithOneInstruction(): void
+    {
+        if ($condition) {
+            echo 'one instruction is left alone';
+        }
+    }
+
+    public function trailingIfWithMultipleInstructions(): void
+    {
+        if ($condition) {
+            echo 'more than one instruction';
+            echo 'still requires an early exit';
+        }
+    }
 }

--- a/tests/input/traits-uses.php
+++ b/tests/input/traits-uses.php
@@ -14,11 +14,11 @@ class Bar
 {
     use T2, T3;
 
+    use T5;
+
     use T4 {
         x as public;
     }
-
-    use T5;
     public function __construct()
     {
     }

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -13,7 +13,7 @@ index 8547171..f01ece0 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
 -tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
+-tests/input/example-class.php                         49      0
 -tests/input/ExampleBackedEnum.php                     5       0
 -tests/input/Exceptions.php                            1       0
 +tests/input/EarlyReturn.php                           7       0
@@ -49,7 +49,7 @@ index 8547171..f01ece0 100644
 -tests/input/TrailingCommaOnFunctions.php              6       0
 +tests/input/TrailingCommaOnFunctions.php              2       0
  tests/input/traits-uses.php                           12      0
--tests/input/type-hints.php                            9       0
+-tests/input/type-hints.php                            10      0
 +tests/input/type-hints.php                            8       0
  tests/input/UnusedVariables.php                       1       0
  tests/input/use-ordering.php                          2       0
@@ -57,10 +57,10 @@ index 8547171..f01ece0 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+-A TOTAL OF 484 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 +A TOTAL OF 434 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 398 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 349 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -8,14 +8,14 @@ index 8547171..f01ece0 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
--tests/input/EarlyReturn.php                           7       0
+-tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 -tests/input/ExampleBackedEnum.php                     5       0
 -tests/input/Exceptions.php                            1       0
-+tests/input/EarlyReturn.php                           6       0
++tests/input/EarlyReturn.php                           7       0
 +tests/input/example-class.php                         44      0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -2,7 +2,8 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 8547171..f01ece0 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -13,31 +13,28 @@ tests/input/class-references.php                      10      2
+@@ -13,32 +13,28 @@ tests/input/class-references.php                      10      2
+-tests/input/ClassKeywordOrder.php                     1       0
  tests/input/ClassPropertySpacing.php                  2       0
  tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
@@ -41,7 +42,7 @@ index 8547171..f01ece0 100644
  tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
-@@ -47,15 +44,15 @@ tests/input/strings.php                               3       0
+@@ -47,15 +43,15 @@ tests/input/strings.php                               3       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
@@ -56,12 +57,36 @@ index 8547171..f01ece0 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 +A TOTAL OF 433 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 348 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
+diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
+index 29f6164..4b28352 100644
+--- a/tests/fixed/ClassKeywordOrder.php
++++ b/tests/fixed/ClassKeywordOrder.php
+@@ -3,7 +3,3 @@
+ declare(strict_types=1);
+
+ namespace ClassKeywordOrder;
+-
+-final readonly class ClassKeywordOrder
+-{
+-}
+diff --git a/tests/input/ClassKeywordOrder.php b/tests/input/ClassKeywordOrder.php
+index dcad6ca..4b28352 100644
+--- a/tests/input/ClassKeywordOrder.php
++++ b/tests/input/ClassKeywordOrder.php
+@@ -3,7 +3,3 @@
+ declare(strict_types=1);
+
+ namespace ClassKeywordOrder;
+-
+-readonly final class ClassKeywordOrder
+-{
+-}
 diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.php
 index 480e419..a653086 100644
 --- a/tests/fixed/ControlStructures.php

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -48,7 +48,7 @@ index 8547171..f01ece0 100644
  tests/input/trailing_comma_on_array.php               1       0
 -tests/input/TrailingCommaOnFunctions.php              6       0
 +tests/input/TrailingCommaOnFunctions.php              2       0
- tests/input/traits-uses.php                           11      0
+ tests/input/traits-uses.php                           12      0
 -tests/input/type-hints.php                            9       0
 +tests/input/type-hints.php                            8       0
  tests/input/UnusedVariables.php                       1       0
@@ -57,11 +57,11 @@ index 8547171..f01ece0 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 433 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 434 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 348 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 349 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -13,9 +13,9 @@ index 9b19b9e..760ee4a 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
+-tests/input/example-class.php                         49      0
 -tests/input/ExampleBackedEnum.php                     5       0
-+tests/input/example-class.php                         47      0
++tests/input/example-class.php                         48      0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
@@ -33,11 +33,11 @@ index 9b19b9e..760ee4a 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 484 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 466 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 379 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 398 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 381 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -8,10 +8,10 @@ index 9b19b9e..760ee4a 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
- tests/input/EarlyReturn.php                           7       0
+ tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 -tests/input/ExampleBackedEnum.php                     5       0
 +tests/input/example-class.php                         47      0

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -2,7 +2,8 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 9b19b9e..760ee4a 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -13,13 +13,12 @@ tests/input/class-references.php                      10      2
+@@ -13,14 +13,12 @@ tests/input/class-references.php                      10      2
+-tests/input/ClassKeywordOrder.php                     1       0
  tests/input/ClassPropertySpacing.php                  2       0
  tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
@@ -28,16 +29,40 @@ index 9b19b9e..760ee4a 100644
  tests/input/return_type_on_closures.php               26      0
  tests/input/return_type_on_methods.php                22      0
  tests/input/semicolon_spacing.php                     3       0
-@@ -55,7 +54,7 @@ tests/input/use-ordering.php                          2       0
+@@ -55,7 +53,7 @@ tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 +A TOTAL OF 463 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 378 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
+diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
+index 29f6164..4b28352 100644
+--- a/tests/fixed/ClassKeywordOrder.php
++++ b/tests/fixed/ClassKeywordOrder.php
+@@ -3,7 +3,3 @@
+ declare(strict_types=1);
+
+ namespace ClassKeywordOrder;
+-
+-final readonly class ClassKeywordOrder
+-{
+-}
+diff --git a/tests/input/ClassKeywordOrder.php b/tests/input/ClassKeywordOrder.php
+index dcad6ca..4b28352 100644
+--- a/tests/input/ClassKeywordOrder.php
++++ b/tests/input/ClassKeywordOrder.php
+@@ -3,7 +3,3 @@
+ declare(strict_types=1);
+
+ namespace ClassKeywordOrder;
+-
+-readonly final class ClassKeywordOrder
+-{
+-}
 diff --git a/tests/fixed/ExampleBackedEnum.php b/tests/fixed/ExampleBackedEnum.php
 index fd701eb..fe54eb9 100644
 --- a/tests/fixed/ExampleBackedEnum.php

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -33,11 +33,11 @@ index 9b19b9e..760ee4a 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 463 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 378 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 379 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -13,8 +13,8 @@ index 8547171..a7a42fa 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
-+tests/input/example-class.php                         47      0
+-tests/input/example-class.php                         49      0
++tests/input/example-class.php                         48      0
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 474 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 484 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 476 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 389 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 398 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -2,7 +2,8 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 8547171..a7a42fa 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -13,12 +13,12 @@ tests/input/class-references.php                      10      2
+@@ -13,13 +13,12 @@ tests/input/class-references.php                      10      2
+-tests/input/ClassKeywordOrder.php                     1       0
  tests/input/ClassPropertySpacing.php                  2       0
  tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
@@ -17,16 +18,40 @@ index 8547171..a7a42fa 100644
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
-@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          2       0
+@@ -55,7 +54,7 @@ tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 +A TOTAL OF 473 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 388 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
+diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
+index 29f6164..4b28352 100644
+--- a/tests/fixed/ClassKeywordOrder.php
++++ b/tests/fixed/ClassKeywordOrder.php
+@@ -3,7 +3,3 @@
+ declare(strict_types=1);
+
+ namespace ClassKeywordOrder;
+-
+-final readonly class ClassKeywordOrder
+-{
+-}
+diff --git a/tests/input/ClassKeywordOrder.php b/tests/input/ClassKeywordOrder.php
+index dcad6ca..4b28352 100644
+--- a/tests/input/ClassKeywordOrder.php
++++ b/tests/input/ClassKeywordOrder.php
+@@ -3,7 +3,3 @@
+ declare(strict_types=1);
+
+ namespace ClassKeywordOrder;
+-
+-readonly final class ClassKeywordOrder
+-{
+-}
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644
 --- a/tests/fixed/constants-var.php

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 473 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 474 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 388 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 389 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -8,10 +8,10 @@ index 8547171..a7a42fa 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
- tests/input/EarlyReturn.php                           7       0
+ tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 +tests/input/example-class.php                         47      0
  tests/input/ExampleBackedEnum.php                     5       0

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -13,8 +13,8 @@ index 8547171..a7a42fa 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
-+tests/input/example-class.php                         47      0
+-tests/input/example-class.php                         49      0
++tests/input/example-class.php                         48      0
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 475 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+-A TOTAL OF 484 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 390 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 398 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 392 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 474 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 475 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 389 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 390 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -2,7 +2,8 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 8547171..a7a42fa 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -13,12 +13,12 @@ tests/input/class-references.php                      10      2
+@@ -13,13 +13,13 @@ tests/input/class-references.php                      10      2
+ tests/input/ClassKeywordOrder.php                     1       0
  tests/input/ClassPropertySpacing.php                  2       0
  tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
@@ -21,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
-+A TOTAL OF 473 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 474 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 388 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 389 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -8,10 +8,10 @@ index 8547171..a7a42fa 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
- tests/input/EarlyReturn.php                           7       0
+ tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 +tests/input/example-class.php                         47      0
  tests/input/ExampleBackedEnum.php                     5       0


### PR DESCRIPTION
Enables `SlevomatCodingStandard.TypeHints.DNFTypeHintFormat` `enableForDocComments` so DNF type formatting is also enforced in PHPDoc annotations.

Raises the minimum `slevomat/coding-standard` version to `^8.29`, where the option was introduced.